### PR TITLE
Dashboard fails reading reminders as 0 int beginHash is not supported in ReadRangeRows

### DIFF
--- a/src/Orleans.Reminders.CosmosDB/Sprocs/ReadRangeRows.js
+++ b/src/Orleans.Reminders.CosmosDB/Sprocs/ReadRangeRows.js
@@ -4,7 +4,7 @@ function ReadRangeRows(serviceId, beginHash, endHash) {
   var response = context.getResponse();
 
   if (!serviceId) throw new Error('serviceId is required');
-  if (!beginHash) throw new Error('beginHash is required');
+  if (isNaN(beginHash) && !beginHash) throw new Error('beginHash is required');
   if (!endHash) throw new Error('endHash is required');
 
   var query = 'SELECT * FROM c WHERE c.ServiceId = "' + serviceId + '"';


### PR DESCRIPTION
The following is logged to console if beginHash is an int of 0.

fail: CosmosDBReminderTable[0]
      Failure reading reminders for Service 00000000-0000-0000-0000-000000000000 for range 0 to 4294967295.
Microsoft.Azure.Documents.DocumentClientException: Message: {"Errors":["Encountered exception while executing Javascript. Exception = Error: beginHash is required\r\nStack trace: Error: beginHash is required\n   at ReadRangeRows (ReadRangeRows.js:7:19)\n   at __docDbMain (ReadRangeRows.js:31:5)\n   at Global code (ReadRangeRows.js:1:2)"]}
ActivityId: 72a51c2e-fc3f-475e-a43c-5e96c9fa1920, Request URI: /apps/ae55afb7-915e-43d3-9f60-6b6dfcc18b5a/services/75db3f4c-edfc-45a3-b5c2-a533ec676973/partitions/69a35bf2-5724-4ec1-8afe-67f14f754add/replicas/131653334037866222p, RequestStats: , SDK: Microsoft.Azure.Documents.Common/1.20.0.0, Windows/10.0.15063 documentdb-netcore-sdk/1.8.2