### PR TITLE
Supports configuration of throughput on database level

### DIFF
--- a/src/Orleans.Persistence.CosmosDB/Options/CosmosDBStorageOptions.cs
+++ b/src/Orleans.Persistence.CosmosDB/Options/CosmosDBStorageOptions.cs
@@ -15,13 +15,21 @@ namespace Orleans.Persistence.CosmosDB
         private const string ORLEANS_DB = "Orleans";
         internal const string ORLEANS_STORAGE_COLLECTION = "OrleansStorage";
         private const int ORLEANS_STORAGE_COLLECTION_THROUGHPUT = 400;
-
+        private const int ORLEANS_DATABASE_THROUGHPUT = 0;
 
         [Redact]
         public string AccountKey { get; set; }
         public string AccountEndpoint { get; set; }
         public string DB { get; set; } = ORLEANS_DB;
+
+        /// <summary>
+        /// Database configured throughput, if set to 0 it will not be configured and collection throughput must be set. See https://docs.microsoft.com/en-us/azure/cosmos-db/set-throughput 
+        /// </summary>
+        public int DatabaseThroughput { get; set; } = ORLEANS_STORAGE_COLLECTION_THROUGHPUT;
         public string Collection { get; set; } = ORLEANS_STORAGE_COLLECTION;
+        /// <summary>
+        /// RU units for collection, can be set to 0 if throughput is specified on database level. See https://docs.microsoft.com/en-us/azure/cosmos-db/set-throughput
+        /// </summary>
         public int CollectionThroughput { get; set; } = ORLEANS_STORAGE_COLLECTION_THROUGHPUT;
         public bool CanCreateResources { get; set; }
         public bool DeleteStateOnClear { get; set; }
@@ -99,9 +107,9 @@ namespace Orleans.Persistence.CosmosDB
                 throw new OrleansConfigurationException(
                     $"Configuration for CosmosDBStorage {this.name} is invalid. {nameof(this.options.Collection)} is not valid.");
 
-            if (this.options.CollectionThroughput == 0)
+            if (this.options.CollectionThroughput < 400 && this.options.DatabaseThroughput < 400)
                 throw new OrleansConfigurationException(
-                    $"Configuration for CosmosDBStorage {this.name} is invalid. {nameof(this.options.CollectionThroughput)} is not valid.");
+                    $"Configuration for CosmosDBStorage {this.name} is invalid. Either {nameof(this.options.DatabaseThroughput)} or {nameof(this.options.CollectionThroughput)} must exceed 400.");
         }
     }
 }

--- a/test/Orleans.CosmosDB.Tests/ThroughputConfigurationTests.cs
+++ b/test/Orleans.CosmosDB.Tests/ThroughputConfigurationTests.cs
@@ -1,0 +1,106 @@
+using System;
+using Orleans.CosmosDB.Tests.Grains;
+using Orleans.Hosting;
+using Orleans.Persistence.CosmosDB;
+using Orleans.Runtime;
+using Orleans.Storage;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using static Orleans.CosmosDB.Tests.ThroughputConfigurationTests;
+
+// For Index coverage CreateDocumentQuery
+using Microsoft.Azure.Documents.Client;
+using Microsoft.Azure.Documents;
+
+namespace Orleans.CosmosDB.Tests
+{
+    public class ThroughputConfigurationTests : IClassFixture<StorageFixture>
+    {
+        //private const string StorageDbName = "OrleansStorageTest";
+        private const string DatabaseName = "DatabaseRUTest";
+        private StorageFixture _fixture;
+
+        public class StorageFixture : OrleansFixture
+        {
+            internal string AccountEndpoint;
+            internal string AccountKey;
+
+            protected override ISiloHostBuilder PreBuild(ISiloHostBuilder builder)
+            {
+                OrleansFixture.GetAccountInfo(out this.AccountEndpoint, out this.AccountKey);
+
+                return builder
+                    .AddCosmosDBGrainStorage(OrleansFixture.TEST_STORAGE, opt =>
+                    {
+                        opt.AccountEndpoint = this.AccountEndpoint;
+                        opt.AccountKey = this.AccountKey;
+                        opt.ConnectionMode = ConnectionMode.Gateway;
+                        opt.DropDatabaseOnInit = true;
+                        opt.AutoUpdateStoredProcedures = true;
+                        opt.CanCreateResources = true;
+                        opt.DB = DatabaseName;
+                        opt.DatabaseThroughput = 1000;
+                        opt.CollectionThroughput = 0;
+                        opt.Collection = "RUTest";
+                    })
+                    .AddCosmosDBGrainStorage("Second", opt =>
+                    {
+                        opt.AccountEndpoint = this.AccountEndpoint;
+                        opt.AccountKey = this.AccountKey;
+                        opt.ConnectionMode = ConnectionMode.Gateway;
+                        opt.DropDatabaseOnInit = true;
+                        opt.AutoUpdateStoredProcedures = true;
+                        opt.CanCreateResources = true;
+                        opt.DB = DatabaseName;
+                        opt.DatabaseThroughput = 1000;
+                        opt.CollectionThroughput = 500;
+                        opt.Collection = "RUTest2";
+                    });
+
+            }
+        }
+
+        public ThroughputConfigurationTests(StorageFixture fixture) => this._fixture = fixture;
+
+        [Fact]
+        public async Task VerifyDbThroughput()
+        {
+            var storage = this._fixture.Silo.Services.GetServiceByName<IGrainStorage>(OrleansFixture.TEST_STORAGE) as CosmosDBGrainStorage;
+            var dbClient = storage._dbClient;
+            var offers = dbClient.CreateOfferQuery().ToList();
+
+            //Database has offer
+            var database = (Database)(await dbClient.ReadDatabaseAsync(UriFactory.CreateDatabaseUri(DatabaseName)));
+            var offerDatabase = (OfferV2)offers.Single(o => o.ResourceLink == database.SelfLink);
+            Assert.Equal(1000, offerDatabase.Content.OfferThroughput);
+        }
+
+        [Fact]
+        public async Task VerifyCollectionWithoutOffer()
+        {
+            var storage = this._fixture.Silo.Services.GetServiceByName<IGrainStorage>(OrleansFixture.TEST_STORAGE) as CosmosDBGrainStorage;
+            var dbClient = storage._dbClient;
+            var offers = dbClient.CreateOfferQuery().ToList();
+
+            //Collection RUTest does not
+            var collection1 = (DocumentCollection)(await dbClient.ReadDocumentCollectionAsync(UriFactory.CreateDocumentCollectionUri(DatabaseName, "RUTest")));
+            var offerCollection1 = offers.FirstOrDefault(o => o.ResourceLink == collection1.SelfLink);
+            Assert.Null(offerCollection1);
+        }
+
+        [Fact]
+        public async Task VerifiyCollectionWithOfferInDbWithOffer()
+        {
+            var storage = this._fixture.Silo.Services.GetServiceByName<IGrainStorage>(OrleansFixture.TEST_STORAGE) as CosmosDBGrainStorage;
+            var dbClient = storage._dbClient;
+            var offers = dbClient.CreateOfferQuery().ToList();
+
+            //Collection RUTest2 has offer
+            var collection2 = (DocumentCollection)(await dbClient.ReadDocumentCollectionAsync(UriFactory.CreateDocumentCollectionUri(DatabaseName, "RUTest2")));
+            var offerCollection2 = (OfferV2)offers.Single(o => o.ResourceLink == collection2.SelfLink);
+            Assert.Equal(500, offerCollection2.Content.OfferThroughput);
+        }
+    }
+}


### PR DESCRIPTION
We have quite a few containers (collections) just to separate data, due to multitenancy and separation of grains used as a cache and grains with state we own. Our multitenancy usage is also related to  time (service A during daytime, and service B during evening), hence having RU at database makes sense. 

Default is RU at container level, and it is possible to support RU on database and collection. 

https://docs.microsoft.com/en-us/azure/cosmos-db/set-throughput