### PR TITLE
set grainState.ETag = null, while clear state and delete state on clear

### DIFF
--- a/src/Orleans.Persistence.CosmosDB/CosmosDBGrainStorage.cs
+++ b/src/Orleans.Persistence.CosmosDB/CosmosDBGrainStorage.cs
@@ -257,6 +257,8 @@ namespace Orleans.Persistence.CosmosDB
 
                     await ExecuteWithRetries(() => this._container.DeleteItemAsync<GrainStateEntity>(
                         id, pk, requestOptions));
+
+                    grainState.ETag = null;
                 }
                 else
                 {


### PR DESCRIPTION
if DeleteStateOnClear is set to true, the clear operation will not reset the grainState.ETag.
That will course the same grain's next write operation fail, when the grain is not deactivate.