### PR TITLE
Pass StorageOptions to GrainStorage

### DIFF
--- a/src/Orleans.Persistence.CosmosDB/CosmosDBGrainStorage.cs
+++ b/src/Orleans.Persistence.CosmosDB/CosmosDBGrainStorage.cs
@@ -464,7 +464,7 @@ namespace Orleans.Persistence.CosmosDB
     {
         public static IGrainStorage Create(IServiceProvider services, string name)
         {
-            var options = services.GetRequiredService<IOptionsMonitor<CosmosDBGrainStorage>>().Get(name);
+            var options = services.GetRequiredService<IOptionsMonitor<CosmosDBStorageOptions>>().Get(name);
             return ActivatorUtilities.CreateInstance<CosmosDBGrainStorage>(services, options, name);
         }
     }


### PR DESCRIPTION
That should work better than trying to pass GrainStorage to itself.

Fixes a crash when trying to use this.