### PR TITLE
Updating Orleans and Cosmos Db Packages and dealing with breaking change

### DIFF
--- a/src/Orleans.Persistence.CosmosDB/CosmosDBGrainStorage.cs
+++ b/src/Orleans.Persistence.CosmosDB/CosmosDBGrainStorage.cs
@@ -153,12 +153,14 @@ namespace Orleans.Persistence.CosmosDB
                 if (doc.Resource.State != null)
                 {
                     grainState.State = JsonConvert.DeserializeObject(doc.Resource.State.ToString(), grainState.State.GetType(), this._options.JsonSerializerSettings);
+                    grainState.RecordExists = true;
                 }
                 else
                 {
                     grainState.State = Activator.CreateInstance(grainState.State.GetType());
+                    grainState.RecordExists = false;
                 }
-                
+
                 grainState.ETag = doc.Resource.ETag;
             }
             catch (CosmosException dce)
@@ -224,6 +226,7 @@ namespace Orleans.Persistence.CosmosDB
                     grainState.ETag = response.Resource.ETag;
                 }
 
+                grainState.RecordExists = true;
             }
             catch (CosmosException dce) when (dce.StatusCode == HttpStatusCode.PreconditionFailed)
             {
@@ -259,6 +262,7 @@ namespace Orleans.Persistence.CosmosDB
                         id, pk, requestOptions));
 
                     grainState.ETag = null;
+                    grainState.RecordExists = false;
                 }
                 else
                 {
@@ -278,6 +282,7 @@ namespace Orleans.Persistence.CosmosDB
                         .ConfigureAwait(false);
 
                     grainState.ETag = response.Resource.ETag;
+                    grainState.RecordExists = true;
                 }
             }
             catch (Exception exc)

--- a/src/Orleans.Persistence.CosmosDB/Orleans.Persistence.CosmosDB.csproj
+++ b/src/Orleans.Persistence.CosmosDB/Orleans.Persistence.CosmosDB.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -27,9 +27,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.6.0" />
-    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.0.2" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.17.1" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.4.1" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Hi folks,

We have had a go at updating the package references to Microsoft.Azure.Cosmos and Microsoft.Orleans.OrleansRuntime to their current latest versions (3.17.1 and 3.4.1 respectively).

As part of this we had to make some changes to the methods in `CosmosDBGrainStorage` to set `grainState.RecordExists` appropriately, as a breaking change was introduced in Orleans 3.3.0.

Cheers,

Nick