### PR TITLE
Fix for UpdateIAmAlive in CosmosDBMembershipTable.cs

### DIFF
--- a/src/Orleans.Clustering.CosmosDB/Orleans.Clustering.CosmosDB.csproj
+++ b/src/Orleans.Clustering.CosmosDB/Orleans.Clustering.CosmosDB.csproj
@@ -27,8 +27,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.6.0" />
-    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.0.2" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.17.1" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.4.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Hello again folks,

We have been trying out Cosmos Db based clustering and came across [issue 6987](https://github.com/dotnet/orleans/issues/6987) already reported in the `dotnet/orleans` repo.

On investigation, the issue is caused by Orleans passing a `MembershipEntry` to `UpdateIAmAlive` that only has the `SiloAddress` and `IAmAliveTime` properties filed with data. After being converted to a `SiloEntity` by `ConstructSiloEntityId`, the save to Cosmos Db would fail due to `StartTime` (as well as the rest of the properties) just being their default values.

This pr pulls the existing `SiloEntity` from Cosmos Db, updates the `IAmAliveTime` property and saves it back to Cosmos Db.

From what we can tell, this is what used to happen in `UpdateIAmAlive.js` before it was removed.

Cheers,

Nick