### PR TITLE
Fix runtime issue with latest Cosmos package

### DIFF
--- a/src/Orleans.Clustering.CosmosDB/Orleans.Clustering.CosmosDB.csproj
+++ b/src/Orleans.Clustering.CosmosDB/Orleans.Clustering.CosmosDB.csproj
@@ -27,8 +27,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.6.0" />
-    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.0.2" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.17.1" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.4.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
We found a runtime issue when running Orleans.Clustering.CosmosDB with latest Microsoft.Azure.Cosmos 3.17.1 due to method signature breaking change:

System.MissingMethodException: 
Method not found: 'System.Linq.IOrderedQueryable`1<!!0> Microsoft.Azure.Cosmos.Container.GetItemLinqQueryable(Boolean, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)'.
   at Orleans.Clustering.CosmosDB.CosmosDBGatewayListProvider.GetGateways()

This PR updates CosmosDB and Orleans packages to rebuild Orleans.Clustering.CosmosDB:

- Microsoft.Azure.Cosmos => 3.17.1
- Microsoft.Orleans.OrleansRuntime => 3.4.2
