### PR TITLE
Support AAD RBAC for CosmosDB access

### DIFF
--- a/StartEmulator.cmd
+++ b/StartEmulator.cmd
@@ -3,4 +3,4 @@ set containerName=azure-cosmosdb-emulator
 set hostDirectory=%LOCALAPPDATA%\azure-cosmosdb-emulator.hostd
 md %hostDirectory% 2>nul
 REM docker run --name %containerName% --memory 2GB --mount "type=bind,source=%hostDirectory%,destination=C:\CosmosDB.Emulator\bind-mount" -P --interactive --tty microsoft/azure-cosmosdb-emulator
-docker run --name %containerName% --memory 2GB --mount "type=bind,source=%hostDirectory%,destination=C:\CosmosDB.Emulator\bind-mount" -p 8081:8081 -p 8900:8900 -p 8901:8901 -p 8979:8979 -p 10250:10250 -p 10251:10251 -p 10252:10252 -p 10253:10253 -p 10254:10254 -p 10255:10255 -p 10256:10256 -p 10350:10350 microsoft/azure-cosmosdb-emulator
+docker run --name %containerName% --memory 2GB --mount "type=bind,source=%hostDirectory%,destination=C:\CosmosDB.Emulator\bind-mount" --interactive --tty -p 8081:8081 -p 8900:8900 -p 8901:8901 -p 8979:8979 -p 10250:10250 -p 10251:10251 -p 10252:10252 -p 10253:10253 -p 10254:10254 -p 10255:10255 -p 10256:10256 -p 10350:10350 microsoft/azure-cosmosdb-emulator

--- a/src/Orleans.Clustering.CosmosDB/Options/CosmosDBClusteringOptions.cs
+++ b/src/Orleans.Clustering.CosmosDB/Options/CosmosDBClusteringOptions.cs
@@ -10,6 +10,7 @@ namespace Orleans.Clustering.CosmosDB
         private const string ORLEANS_CLUSTER_COLLECTION = "OrleansCluster";
         private const int ORLEANS_CLUSTER_COLLECTION_THROUGHPUT = 400;
 
+        public CosmosClient ProvisionClient { get; set; }
         public CosmosClient Client { get; set; }
         public string AccountEndpoint { get; set; }
         [Redact]

--- a/src/Orleans.Persistence.CosmosDB/CosmosDBGrainStorage.cs
+++ b/src/Orleans.Persistence.CosmosDB/CosmosDBGrainStorage.cs
@@ -40,6 +40,7 @@ namespace Orleans.Persistence.CosmosDB
         private readonly ITypeResolver _typeResolver;
         private readonly CosmosDBStorageOptions _options;
         private readonly IPartitionKeyProvider _partitionKeyProvider;
+        private CosmosClient _provisionClient;
         internal CosmosClient _cosmos;  // internal for test
         internal Container _container;
 
@@ -109,6 +110,14 @@ namespace Orleans.Persistence.CosmosDB
                         this._options.AccountKey,
                         new CosmosClientOptions { ConnectionMode = this._options.ConnectionMode }
                     );
+                }
+                if (this._options.ProvisionClient != null)
+                {
+                    this._provisionClient = this._options.ProvisionClient;
+                }
+                else
+                {
+                    this._provisionClient = this._cosmos;
                 }
                 this._container = this._cosmos.GetDatabase(this._options.DB).GetContainer(this._options.Collection);
 
@@ -351,6 +360,7 @@ namespace Orleans.Persistence.CosmosDB
 
         public Task Close(CancellationToken ct)
         {
+            this._provisionClient.Dispose();
             this._cosmos.Dispose();
             return Task.CompletedTask;
         }
@@ -410,7 +420,7 @@ namespace Orleans.Persistence.CosmosDB
                     ? (int?)this._options.DatabaseThroughput
                     : null;
 
-            var dbResponse = await this._cosmos.CreateDatabaseIfNotExistsAsync(this._options.DB, offerThroughput);
+            var dbResponse = await this._provisionClient.CreateDatabaseIfNotExistsAsync(this._options.DB, offerThroughput);
             var db = dbResponse.Database;
 
             var stateCollection = new ContainerProperties(this._options.Collection, DEFAULT_PARTITION_KEY_PATH);
@@ -454,7 +464,7 @@ namespace Orleans.Persistence.CosmosDB
         {
             try
             {
-                var db = this._cosmos.GetDatabase(this._options.DB);
+                var db = this._provisionClient.GetDatabase(this._options.DB);
                 await db.ReadAsync();
                 await db.DeleteAsync();
             }

--- a/src/Orleans.Persistence.CosmosDB/Options/CosmosDBStorageOptions.cs
+++ b/src/Orleans.Persistence.CosmosDB/Options/CosmosDBStorageOptions.cs
@@ -12,6 +12,7 @@ namespace Orleans.Persistence.CosmosDB
         internal const string ORLEANS_STORAGE_COLLECTION = "OrleansStorage";
         private const int ORLEANS_STORAGE_COLLECTION_THROUGHPUT = 400;
 
+        public CosmosClient ProvisionClient { get; set; }
         public CosmosClient Client { get; set; }
 
         [Redact]

--- a/src/Orleans.Reminders.CosmosDB/Options/CosmosDBReminderStorageOptions.cs
+++ b/src/Orleans.Reminders.CosmosDB/Options/CosmosDBReminderStorageOptions.cs
@@ -9,6 +9,8 @@ namespace Orleans.Reminders.CosmosDB
         private const string ORLEANS_DB = "Orleans";
         private const string ORLEANS_REMINDERS_COLLECTION = "OrleansReminders";
         private const int ORLEANS_STORAGE_COLLECTION_THROUGHPUT = 400;
+
+        public CosmosClient ProvisionClient { get; set; }
         public CosmosClient Client { get; set; }
         public string AccountEndpoint { get; set; }
         [Redact]

--- a/test/Orleans.CosmosDB.Tests/IndexTests.cs
+++ b/test/Orleans.CosmosDB.Tests/IndexTests.cs
@@ -45,6 +45,7 @@ namespace Orleans.CosmosDB.Tests
                 return builder
                     .AddCosmosDBGrainStorage(OrleansFixture.TEST_STORAGE, opt =>
                     {
+                        opt.ProvisionClient = dbClient;
                         opt.Client = dbClient;
                         opt.DropDatabaseOnInit = true;
                         opt.CanCreateResources = true;

--- a/test/Orleans.CosmosDB.Tests/MBTTests.cs
+++ b/test/Orleans.CosmosDB.Tests/MBTTests.cs
@@ -33,6 +33,7 @@ namespace Orleans.CosmosDB.Tests
 
             var options = new CosmosDBClusteringOptions()
             {
+                ProvisionClient = dbClient,
                 Client = dbClient,
                 CanCreateResources = true,
                 DropDatabaseOnInit = true,

--- a/test/Orleans.CosmosDB.Tests/PersistenceTests.cs
+++ b/test/Orleans.CosmosDB.Tests/PersistenceTests.cs
@@ -56,6 +56,7 @@ namespace Orleans.CosmosDB.Tests
                 return builder
                     .AddCosmosDBGrainStorage<PrimaryKeyPartitionKeyProvider>(OrleansFixture.TEST_STORAGE, opt =>
                     {
+                        opt.ProvisionClient = dbClient;
                         opt.Client = dbClient;
                         opt.DropDatabaseOnInit = true;
                         opt.CanCreateResources = true;

--- a/test/Orleans.CosmosDB.Tests/ReminderTests.cs
+++ b/test/Orleans.CosmosDB.Tests/ReminderTests.cs
@@ -34,6 +34,7 @@ namespace Orleans.CosmosDB.Tests
                     .AddMemoryGrainStorage(OrleansFixture.TEST_STORAGE)
                     .UseCosmosDBReminderService(opt =>
                     {
+                        opt.ProvisionClient = dbClient;
                         opt.Client = dbClient;
                         opt.CanCreateResources = true;
                         opt.DB = DatabaseName;


### PR DESCRIPTION
When using managed identity to access CosmosDB with dataplane SDK, it's currently not supported to do database/container provisioning operations like create/delete.

This PR adds another CosmosClient, called ProvisionClient, to the cosmosdb options. Users can provide both clients to separate their usages:

- ProvisionClient: this client is created with account key credentials, so it's allowed to do database/container provisioning operations;
- Client: this is for data operations only, so it can be created with managed identity to avoid credentials refresh requirements (e.g. account key rotation).

The ProvisionClient is typically only used at service bootstrap time, so no need to think about account key rotation issue.
