### PR TITLE
Add Autoscale options

### DIFF
--- a/src/Orleans.Clustering.CosmosDB/CosmosDBMembershipTable.cs
+++ b/src/Orleans.Clustering.CosmosDB/CosmosDBMembershipTable.cs
@@ -409,8 +409,18 @@ namespace Orleans.Clustering.CosmosDB
             //}
             containerProperties.IndexingPolicy.IndexingMode = IndexingMode.Consistent;
 
-            await dbResponse.CreateContainerIfNotExistsAsync(
-                containerProperties, this._options.CollectionThroughput);
+            if (this._options.UseDedicatedThroughput)
+            {
+                ThroughputProperties throughputProperties = this._options.UseAutoscaleThroughput
+                    ? ThroughputProperties.CreateAutoscaleThroughput(this._options.AutoscaleThroughputMax)
+                    : ThroughputProperties.CreateManualThroughput(this._options.CollectionThroughput);
+                
+                await dbResponse.CreateContainerIfNotExistsAsync(containerProperties, throughputProperties);
+            }
+            else
+            {
+                await dbResponse.CreateContainerIfNotExistsAsync(containerProperties);
+            }
         }
 
         public async Task CleanupDefunctSiloEntries(DateTimeOffset beforeDate)

--- a/src/Orleans.Clustering.CosmosDB/Options/CosmosDBClusteringOptions.cs
+++ b/src/Orleans.Clustering.CosmosDB/Options/CosmosDBClusteringOptions.cs
@@ -8,7 +8,10 @@ namespace Orleans.Clustering.CosmosDB
     {
         private const string ORLEANS_DB = "Orleans";
         private const string ORLEANS_CLUSTER_COLLECTION = "OrleansCluster";
+        private const bool ORLEANS_CLUSTER_DEDICATED_THROUGHPUT_ENABLED = true;
         private const int ORLEANS_CLUSTER_COLLECTION_THROUGHPUT = 400;
+        private const bool ORLEANS_CLUSTER_AUTOSCALE_THROUGHPUT_ENABLED = false;
+        private const int ORLEANS_CLUSTER_AUTOSCALE_THROUGHPUT_MAX = 4000;
 
         public CosmosClient Client { get; set; }
         public string AccountEndpoint { get; set; }
@@ -17,7 +20,11 @@ namespace Orleans.Clustering.CosmosDB
         public bool CanCreateResources { get; set; }
         public string DB { get; set; } = ORLEANS_DB;
         public string Collection { get; set; } = ORLEANS_CLUSTER_COLLECTION;
+        public bool UseDedicatedThroughput { get; set; } = ORLEANS_CLUSTER_DEDICATED_THROUGHPUT_ENABLED;
         public int CollectionThroughput { get; set; } = ORLEANS_CLUSTER_COLLECTION_THROUGHPUT;
+        public bool UseAutoscaleThroughput { get; set; } = ORLEANS_CLUSTER_AUTOSCALE_THROUGHPUT_ENABLED;
+        public int AutoscaleThroughputMax { get; set; } = ORLEANS_CLUSTER_AUTOSCALE_THROUGHPUT_MAX;
+
 
         [JsonConverter(typeof(StringEnumConverter))]
         public ConnectionMode ConnectionMode { get; set; } = ConnectionMode.Direct;

--- a/src/Orleans.Persistence.CosmosDB/CosmosDBGrainStorage.cs
+++ b/src/Orleans.Persistence.CosmosDB/CosmosDBGrainStorage.cs
@@ -405,10 +405,20 @@ namespace Orleans.Persistence.CosmosDB
 
         private async Task TryCreateCosmosDBResources()
         {
-            var offerThroughput =
-                    this._options.DatabaseThroughput >= 400
-                    ? (int?)this._options.DatabaseThroughput
-                    : null;
+            DatabaseResponse dbResponse;
+
+            if (this._options.DatabaseUseSharedThroughput)
+            {
+                var throughputProperties = this._options.DatabaseUseAutoscaleThroughput
+                    ? ThroughputProperties.CreateAutoscaleThroughput(this._options.DatabaseAutoscaleThroughputMax)
+                    : ThroughputProperties.CreateManualThroughput(this._options.DatabaseThroughput);
+                
+                dbResponse = await this._cosmos.CreateDatabaseIfNotExistsAsync(this._options.DB, throughputProperties);
+            }
+            else
+            {
+                dbResponse = await this._cosmos.CreateDatabaseIfNotExistsAsync(this._options.DB);
+            }
 
             var dbResponse = await this._cosmos.CreateDatabaseIfNotExistsAsync(this._options.DB, offerThroughput);
             var db = dbResponse.Database;
@@ -430,8 +440,20 @@ namespace Orleans.Persistence.CosmosDB
             const int maxRetries = 3;
             for (var retry = 0; retry <= maxRetries; ++retry)
             {
-                var collResponse = await db.CreateContainerIfNotExistsAsync(
-                    stateCollection, offerThroughput);
+                ContainerResponse collResponse;
+
+                if (this._options.UseDedicatedThroughput)
+                {
+                    var throughputProperties = this._options.UseAutoscaleThroughput
+                        ? ThroughputProperties.CreateAutoscaleThroughput(this._options.AutoscaleThroughputMax)
+                        : ThroughputProperties.CreateManualThroughput(this._options.CollectionThroughput);
+                    
+                    dbResponse = await db.CreateContainerIfNotExistsAsync(stateCollection, throughputProperties);
+                }
+                else
+                {
+                    dbResponse = await db.CreateContainerIfNotExistsAsync(stateCollection);
+                }
 
                 if (collResponse.StatusCode == HttpStatusCode.OK || collResponse.StatusCode == HttpStatusCode.Created)
                 {


### PR DESCRIPTION
Currently the Orleans CosmosDB Provider only supports manual throughput options. This PR adds autoscale throughput options, while maintaining the prior default settings.