### PR TITLE
Support different throughput options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.301
+        dotnet-version: 6.0.x
     # - name: Azure Cosmos Emulator
     #   uses: galvesribeiro/AzureCosmosAction@v1.0.0
     # - name: Start CosmosDB Emulator

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.301
+        dotnet-version: 6.0.x
     - name: Pack
       working-directory: src/Orleans.Clustering.CosmosDB
       run: dotnet pack --configuration Release -p:Version=${GITHUB_REF##*/v}

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 *.userosscache
 *.sln.docstates
 
+**/CosmosDBTestSecrets.json
+**/cosmosdbtestsecrets.json
+
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 

--- a/src/Orleans.Clustering.CosmosDB/CosmosDBMembershipTable.cs
+++ b/src/Orleans.Clustering.CosmosDB/CosmosDBMembershipTable.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using Orleans.Clustering.CosmosDB.Extensions;
 
 namespace Orleans.Clustering.CosmosDB
 {
@@ -402,15 +403,12 @@ namespace Orleans.Clustering.CosmosDB
             containerProperties.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/\"SuspectingTimes\"/*" });
             containerProperties.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/StartTime/*" });
             containerProperties.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/IAmAliveTime/*" });
-            //var consistency = this._options.GetConsistencyLevel();
-            //if (consistency.HasValue)
-            //{
-            //    containerProperties.IndexingPolicy.IndexingMode = consistency.Value;
-            //}
             containerProperties.IndexingPolicy.IndexingMode = IndexingMode.Consistent;
 
+
+
             await dbResponse.CreateContainerIfNotExistsAsync(
-                containerProperties, this._options.CollectionThroughput);
+                containerProperties, this._options.GetThroughputProperties());
         }
 
         public async Task CleanupDefunctSiloEntries(DateTimeOffset beforeDate)

--- a/src/Orleans.Clustering.CosmosDB/Extensions/CosmosDBClusteringOptionsExtensions.cs
+++ b/src/Orleans.Clustering.CosmosDB/Extensions/CosmosDBClusteringOptionsExtensions.cs
@@ -1,0 +1,18 @@
+using System;
+using Microsoft.Azure.Cosmos;
+using Orleans.Clustering.CosmosDB.Models;
+
+namespace Orleans.Clustering.CosmosDB.Extensions;
+
+internal static class CosmosDBClusteringOptionsExtensions
+{
+    internal static ThroughputProperties GetThroughputProperties(this CosmosDBClusteringOptions options) =>
+        options.ThroughputMode switch
+        {
+            ThroughputMode.Manual => ThroughputProperties.CreateManualThroughput(options.CollectionThroughput),
+            ThroughputMode.Autoscale => ThroughputProperties.CreateAutoscaleThroughput(
+                options.CollectionThroughput == 400 ? 4000 : options.CollectionThroughput),
+            ThroughputMode.Serverless => null,
+            _ => throw new ArgumentOutOfRangeException(nameof(options.ThroughputMode), $"There is no setup for throughput mode {options.ThroughputMode}")
+        };
+}

--- a/src/Orleans.Clustering.CosmosDB/Models/ThroughputMode.cs
+++ b/src/Orleans.Clustering.CosmosDB/Models/ThroughputMode.cs
@@ -1,0 +1,8 @@
+namespace Orleans.Clustering.CosmosDB.Models;
+
+public enum ThroughputMode
+{
+    Manual,
+    Autoscale,
+    Serverless
+}

--- a/src/Orleans.Clustering.CosmosDB/Options/CosmosDBClusteringOptions.cs
+++ b/src/Orleans.Clustering.CosmosDB/Options/CosmosDBClusteringOptions.cs
@@ -1,6 +1,7 @@
 using Microsoft.Azure.Cosmos;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using Orleans.Clustering.CosmosDB.Models;
 
 namespace Orleans.Clustering.CosmosDB
 {
@@ -10,15 +11,49 @@ namespace Orleans.Clustering.CosmosDB
         private const string ORLEANS_CLUSTER_COLLECTION = "OrleansCluster";
         private const int ORLEANS_CLUSTER_COLLECTION_THROUGHPUT = 400;
 
+        /// <summary>
+        /// The <see cref="CosmosClient"/> used for clustering.
+        /// </summary>
         public CosmosClient Client { get; set; }
+
+        /// <summary>
+        /// Gets or sets the cosmos account endpoint URI. This can be retrieved from the Overview section of the Azure Portal.
+        /// This is required if you are authenticating using tokens.
+        /// <remarks>
+        /// In the form of https://{databaseaccount}.documents.azure.com:443/, see: https://docs.microsoft.com/en-us/rest/api/cosmos-db/cosmosdb-resource-uri-syntax-for-rest
+        /// </remarks>
+        /// </summary>
         public string AccountEndpoint { get; set; }
+
+        /// <summary>
+        /// The account key used for a cosmos DB account.
+        /// </summary>
         [Redact]
         public string AccountKey { get; set; }
+
+        /// <summary>
+        /// Tries to create the database and container used for clustering if it does not exist.
+        /// </summary>
         public bool CanCreateResources { get; set; }
+
+        /// <summary>
+        /// The name of the database to use for clustering information.
+        /// </summary>
         public string DB { get; set; } = ORLEANS_DB;
+
+        /// <summary>
+        /// The name of the collection/container to use to store clustering information.
+        /// </summary>
         public string Collection { get; set; } = ORLEANS_CLUSTER_COLLECTION;
+
+        /// <summary>
+        /// The RU throughput used for the collection/container storing clustering information.
+        /// </summary>
         public int CollectionThroughput { get; set; } = ORLEANS_CLUSTER_COLLECTION_THROUGHPUT;
 
+        /// <summary>
+        /// The connection mode to use when connecting to the azure cosmos DB service.
+        /// </summary>
         [JsonConverter(typeof(StringEnumConverter))]
         public ConnectionMode ConnectionMode { get; set; } = ConnectionMode.Direct;
 
@@ -26,6 +61,12 @@ namespace Orleans.Clustering.CosmosDB
         /// Delete the database on initialization.  Useful for testing scenarios.
         /// </summary>
         public bool DropDatabaseOnInit { get; set; }
+
+        /// <summary>
+        /// The throughput mode to use for the collection/container used for clustering.
+        /// </summary>
+        /// <remarks>If the throughput mode is set to Autoscale then the <see cref="CollectionThroughput"/> will need to be at least 4000 RUs.</remarks>
+        public ThroughputMode ThroughputMode { get; set; } = ThroughputMode.Manual;
 
         // TODO: Consistency level for emulator (defaults to Session; https://docs.microsoft.com/en-us/azure/cosmos-db/local-emulator)
         internal IndexingMode? GetConsistencyLevel() => !string.IsNullOrWhiteSpace(this.AccountEndpoint) && this.AccountEndpoint.Contains("localhost") ? (IndexingMode?)IndexingMode.None : null;

--- a/src/Orleans.Persistence.CosmosDB/CosmosDBGrainStorage.cs
+++ b/src/Orleans.Persistence.CosmosDB/CosmosDBGrainStorage.cs
@@ -407,7 +407,12 @@ namespace Orleans.Persistence.CosmosDB
 
         private async Task TryCreateCosmosDBResources()
         {
-            var dbResponse = await this._cosmos.CreateDatabaseIfNotExistsAsync(this._options.DB);
+            var dbThroughput =
+                this._options.DatabaseThroughput >= 400
+                ? (int?)this._options.DatabaseThroughput
+                : null;
+
+            var dbResponse = await this._cosmos.CreateDatabaseIfNotExistsAsync(this._options.DB, dbThroughput);
             var db = dbResponse.Database;
 
             var stateCollection = new ContainerProperties(this._options.Collection, DEFAULT_PARTITION_KEY_PATH);

--- a/src/Orleans.Persistence.CosmosDB/CosmosDBGrainStorage.cs
+++ b/src/Orleans.Persistence.CosmosDB/CosmosDBGrainStorage.cs
@@ -16,6 +16,7 @@ using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Orleans.Persistence.CosmosDB.Extensions;
 
 namespace Orleans.Persistence.CosmosDB
 {
@@ -160,7 +161,7 @@ namespace Orleans.Persistence.CosmosDB
                     grainState.State = Activator.CreateInstance(grainState.State.GetType());
                     grainState.RecordExists = false;
                 }
-                
+
                 grainState.ETag = doc.Resource.ETag;
             }
             catch (CosmosException dce)
@@ -317,7 +318,7 @@ namespace Orleans.Persistence.CosmosDB
                 var response = await ExecuteWithRetries(async () =>
                 {
                     var pk = new PartitionKey(grainType);
-                    
+
                     var query = this._container.GetItemQueryIterator<GrainStateEntity>(
                         new QueryDefinition($"SELECT * FROM c WHERE c.State.{indexedField} = @key").WithParameter("@key", key),
                         requestOptions: new QueryRequestOptions { PartitionKey = pk }
@@ -406,12 +407,7 @@ namespace Orleans.Persistence.CosmosDB
 
         private async Task TryCreateCosmosDBResources()
         {
-            var offerThroughput =
-                    this._options.DatabaseThroughput >= 400
-                    ? (int?)this._options.DatabaseThroughput
-                    : null;
-
-            var dbResponse = await this._cosmos.CreateDatabaseIfNotExistsAsync(this._options.DB, offerThroughput);
+            var dbResponse = await this._cosmos.CreateDatabaseIfNotExistsAsync(this._options.DB);
             var db = dbResponse.Database;
 
             var stateCollection = new ContainerProperties(this._options.Collection, DEFAULT_PARTITION_KEY_PATH);
@@ -432,7 +428,7 @@ namespace Orleans.Persistence.CosmosDB
             for (var retry = 0; retry <= maxRetries; ++retry)
             {
                 var collResponse = await db.CreateContainerIfNotExistsAsync(
-                    stateCollection, offerThroughput);
+                    stateCollection, this._options.GetThroughputProperties());
 
                 if (collResponse.StatusCode == HttpStatusCode.OK || collResponse.StatusCode == HttpStatusCode.Created)
                 {

--- a/src/Orleans.Persistence.CosmosDB/Extensions/CosmosDBStorageOptionsExtensions.cs
+++ b/src/Orleans.Persistence.CosmosDB/Extensions/CosmosDBStorageOptionsExtensions.cs
@@ -1,0 +1,18 @@
+using System;
+using Microsoft.Azure.Cosmos;
+using Orleans.Persistence.CosmosDB.Models;
+
+namespace Orleans.Persistence.CosmosDB.Extensions;
+
+internal static class CosmosDBStorageOptionsExtensions
+{
+    internal static ThroughputProperties GetThroughputProperties(this CosmosDBStorageOptions options) =>
+        options.ThroughputMode switch
+        {
+            ThroughputMode.Manual => ThroughputProperties.CreateManualThroughput(options.CollectionThroughput),
+            ThroughputMode.Autoscale => ThroughputProperties.CreateAutoscaleThroughput(
+                options.CollectionThroughput == 400 ? 4000 : options.CollectionThroughput),
+            ThroughputMode.Serverless => null,
+            _ => throw new ArgumentOutOfRangeException(nameof(options.ThroughputMode), $"There is no setup for throughput mode {options.ThroughputMode}")
+        };
+}

--- a/src/Orleans.Persistence.CosmosDB/Models/ThroughputMode.cs
+++ b/src/Orleans.Persistence.CosmosDB/Models/ThroughputMode.cs
@@ -1,0 +1,8 @@
+namespace Orleans.Persistence.CosmosDB.Models;
+
+public enum ThroughputMode
+{
+    Manual,
+    Autoscale,
+    Serverless
+}

--- a/src/Orleans.Persistence.CosmosDB/Options/CosmosDBStorageOptions.cs
+++ b/src/Orleans.Persistence.CosmosDB/Options/CosmosDBStorageOptions.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Orleans.Runtime;
 using System.Collections.Generic;
+using Orleans.Persistence.CosmosDB.Models;
 
 namespace Orleans.Persistence.CosmosDB
 {
@@ -59,6 +60,12 @@ namespace Orleans.Persistence.CosmosDB
         /// Stage of silo lifecycle where storage should be initialized.  Storage must be initialized prior to use.
         /// </summary>
         public int InitStage { get; set; } = DEFAULT_INIT_STAGE;
+
+        /// <summary>
+        /// The throughput mode to use for the collection/container used for clustering.
+        /// </summary>
+        /// <remarks>If the throughput mode is set to Autoscale then the <see cref="CollectionThroughput"/> will need to be at least 4000 RUs.</remarks>
+        public ThroughputMode ThroughputMode { get; set; } = ThroughputMode.Manual;
 
         public const int DEFAULT_INIT_STAGE = ServiceLifecycleStage.ApplicationServices;
 

--- a/test/Orleans.CosmosDB.Tests/Extensions/CosmosDBClusteringOptionsExtensionsTests.cs
+++ b/test/Orleans.CosmosDB.Tests/Extensions/CosmosDBClusteringOptionsExtensionsTests.cs
@@ -1,0 +1,77 @@
+using Orleans.Clustering.CosmosDB;
+using Orleans.Clustering.CosmosDB.Extensions;
+using Orleans.Clustering.CosmosDB.Models;
+using Xunit;
+
+namespace Orleans.CosmosDB.Tests.Extensions;
+
+public class CosmosDBClusteringOptionsExtensionsTests
+{
+    [Fact]
+    public void GetThroughputProperties_ManualMode_SetsThroughputCorrectly()
+    {
+        //Arrange
+        var options = new CosmosDBClusteringOptions
+        {
+            ThroughputMode = ThroughputMode.Manual
+        };
+
+        //Act
+        var properties = options.GetThroughputProperties();
+
+        //Assert
+        Assert.Equal(400, properties.Throughput);
+        Assert.Null(properties.AutoscaleMaxThroughput);
+    }
+
+    [Fact]
+    public void GetThroughputProperties_AutoscaleModeDefaultThroughput_CreatesAutoscaleThroughputWith4000RUs()
+    {
+        //Arrange
+        var options = new CosmosDBClusteringOptions
+        {
+            ThroughputMode = ThroughputMode.Autoscale
+        };
+
+        //Act
+        var properties = options.GetThroughputProperties();
+
+        //Assert
+        Assert.Equal(4000, properties.AutoscaleMaxThroughput);
+        Assert.Null(properties.Throughput);
+    }
+
+    [Fact]
+    public void GetThroughputProperties_AutoscaleModeCustomThroughput_CreatesAutoscaleThroughputWithCustomRUs()
+    {
+        //Arrange
+        var options = new CosmosDBClusteringOptions
+        {
+            ThroughputMode = ThroughputMode.Autoscale,
+            CollectionThroughput = 6000
+        };
+
+        //Act
+        var properties = options.GetThroughputProperties();
+
+        //Assert
+        Assert.Equal(6000, properties.AutoscaleMaxThroughput);
+        Assert.Null(properties.Throughput);
+    }
+
+    [Fact]
+    public void GetThroughputProperties_ServerlessMode_ReturnsNullThroughput()
+    {
+        //Arrange
+        var options = new CosmosDBClusteringOptions
+        {
+            ThroughputMode = ThroughputMode.Serverless
+        };
+
+        //Act
+        var properties = options.GetThroughputProperties();
+
+        //Assert
+        Assert.Null(properties);
+    }
+}

--- a/test/Orleans.CosmosDB.Tests/Extensions/CosmosDBStorageOptionsExtensions.cs
+++ b/test/Orleans.CosmosDB.Tests/Extensions/CosmosDBStorageOptionsExtensions.cs
@@ -1,0 +1,77 @@
+using Orleans.Persistence.CosmosDB;
+using Orleans.Persistence.CosmosDB.Extensions;
+using Orleans.Persistence.CosmosDB.Models;
+using Xunit;
+
+namespace Orleans.CosmosDB.Tests.Extensions;
+
+public class CosmosDBStorageOptionsExtensions
+{
+    [Fact]
+    public void GetThroughputProperties_ManualMode_SetsThroughputCorrectly()
+    {
+        //Arrange
+        var options = new CosmosDBStorageOptions
+        {
+            ThroughputMode = ThroughputMode.Manual
+        };
+
+        //Act
+        var properties = options.GetThroughputProperties();
+
+        //Assert
+        Assert.Equal(400, properties.Throughput);
+        Assert.Null(properties.AutoscaleMaxThroughput);
+    }
+
+    [Fact]
+    public void GetThroughputProperties_AutoscaleModeDefaultThroughput_CreatesAutoscaleThroughputWith4000RUs()
+    {
+        //Arrange
+        var options = new CosmosDBStorageOptions
+        {
+            ThroughputMode = ThroughputMode.Autoscale
+        };
+
+        //Act
+        var properties = options.GetThroughputProperties();
+
+        //Assert
+        Assert.Equal(4000, properties.AutoscaleMaxThroughput);
+        Assert.Null(properties.Throughput);
+    }
+
+    [Fact]
+    public void GetThroughputProperties_AutoscaleModeCustomThroughput_CreatesAutoscaleThroughputWithCustomRUs()
+    {
+        //Arrange
+        var options = new CosmosDBStorageOptions
+        {
+            ThroughputMode = ThroughputMode.Autoscale,
+            CollectionThroughput = 6000
+        };
+
+        //Act
+        var properties = options.GetThroughputProperties();
+
+        //Assert
+        Assert.Equal(6000, properties.AutoscaleMaxThroughput);
+        Assert.Null(properties.Throughput);
+    }
+
+    [Fact]
+    public void GetThroughputProperties_ServerlessMode_ReturnsNullThroughput()
+    {
+        //Arrange
+        var options = new CosmosDBStorageOptions
+        {
+            ThroughputMode = ThroughputMode.Serverless
+        };
+
+        //Act
+        var properties = options.GetThroughputProperties();
+
+        //Assert
+        Assert.Null(properties);
+    }
+}

--- a/test/Orleans.CosmosDB.Tests/Orleans.CosmosDB.Tests.csproj
+++ b/test/Orleans.CosmosDB.Tests/Orleans.CosmosDB.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/Orleans.CosmosDB.Tests/OrleansFixture.cs
+++ b/test/Orleans.CosmosDB.Tests/OrleansFixture.cs
@@ -22,7 +22,7 @@ namespace Orleans.CosmosDB.Tests
         // Use distinct silo ports for each test as they may run in parallel.
         private static int portUniquifier;
 
-        public OrleansFixture()
+        protected OrleansFixture()
         {
             string serviceId = Guid.NewGuid().ToString();   // This is required by some tests; Reminders will parse it as a GUID.
 


### PR DESCRIPTION
Small PR to introduce a means to set a throughput requirement. This supports all three main methods supported by Cosmos DB.

1. Manual
2. Autoscale
3. Serverless

Fixes #46 


I also had a few questions.

1. Is there any desire to have a shared package between the 3 projects? For example the `ThroughputMode` that was added could be shared along with a base class for some default options that all packages share. The extensions can then also be shared, reducing code duplication.
2. I updated the test project to run `net6` is there any concerns around that? If so happy to drop it back down.